### PR TITLE
Projectsページのプレビューに使用技術タグを表示

### DIFF
--- a/src/components/preview/event/EventPreveiw.astro
+++ b/src/components/preview/event/EventPreveiw.astro
@@ -38,14 +38,14 @@ const pageUrl = SITE.base + "/events/" + id
 
 <style>
   .EventPreview {
-    --breakpoint: 500px;
+    --breakpoint: 650px;
 
     display: flex;
     justify-content: space-between;
     flex-wrap: wrap;
     gap: 1rem;
   }
-  @media (max-width: 499px) {
+  @media (max-width: 649px) {
     .EventPreview:first-of-type {
       margin-block-start: -1.25rem;
     }
@@ -59,10 +59,10 @@ const pageUrl = SITE.base + "/events/" + id
   }
   .text-inner {
     display: grid;
-    grid-template-columns: max(20%, 105px) 1fr;
+    grid-template-columns: auto 1fr;
     justify-items: start;
     align-items: center;
-    column-gap: 0.75rem;
+    column-gap: 4px;
     position: relative;
     container-type: inline-size;
     width: 100%;
@@ -72,7 +72,7 @@ const pageUrl = SITE.base + "/events/" + id
     justify-content: center;
     gap: 0.5rem;
   }
-  @media (max-width: 499px) {
+  @media (max-width: 549px) {
     .content {
       grid-column: 1 / -1;
     }

--- a/src/components/preview/event/PublishDate.astro
+++ b/src/components/preview/event/PublishDate.astro
@@ -31,12 +31,7 @@ const day = dateObj.getDate().toString().padStart(2, "0")
     font-weight: bold;
     color: light-dark(var(--gray-500), var(--gray-300));
     position: relative;
-    left: -2.5cqw;
-  }
-  @media (min-width: 499px) {
-    .PublishDate {
-      left: 0;
-    }
+    left: -2cqw;
   }
   :is(.background, .text) {
     grid-column: 1 / -1;

--- a/src/components/preview/event/PublishDate.astro
+++ b/src/components/preview/event/PublishDate.astro
@@ -31,7 +31,7 @@ const day = dateObj.getDate().toString().padStart(2, "0")
     font-weight: bold;
     color: light-dark(var(--gray-500), var(--gray-300));
     position: relative;
-    left: -2cqw;
+    left: -2.5cqw;
   }
   :is(.background, .text) {
     grid-column: 1 / -1;

--- a/src/components/preview/project/ProjectPreveiw.astro
+++ b/src/components/preview/project/ProjectPreveiw.astro
@@ -2,6 +2,7 @@
 import type { CollectionEntry } from "astro:content"
 import { Image } from "astro:assets"
 import PublishDate from "./PublishDate.astro"
+import TagList from "$components/article-header/TagList.astro"
 import { SITE } from "$/config"
 import { Icon } from "astro-icon/components"
 
@@ -27,6 +28,7 @@ const pageUrl = SITE.base + "/projects/" + id
         <p class="desc">
           {project.description}
         </p>
+        <TagList tags={project.tags} />
       </div>
     </div>
   </div>
@@ -53,10 +55,10 @@ const pageUrl = SITE.base + "/projects/" + id
   }
   .text-inner {
     display: grid;
-    grid-template-columns: max(20%, 105px) 1fr;
+    grid-template-columns: auto 1fr;
     justify-items: start;
     align-items: center;
-    gap: 0.75rem;
+    gap: 1rem;
     position: relative;
     container-type: inline-size;
     width: 100%;
@@ -89,6 +91,12 @@ const pageUrl = SITE.base + "/projects/" + id
     line-height: 1.5rem;
     hyphens: auto;
     color: light-dark(var(--slate-800), white);
+  }
+  /* TagListは既定で中央寄せだが、プレビューのテキストは常に左揃えなので合わせる */
+  .content :global(.TagList) {
+    justify-content: start;
+    row-gap: 0.5rem;
+    margin-block-start: 0.25rem;
   }
   .ProjectPreview-thumb {
     flex-basis: calc((var(--breakpoint) - 100%) * 999);

--- a/src/components/preview/project/ProjectPreveiw.astro
+++ b/src/components/preview/project/ProjectPreveiw.astro
@@ -40,7 +40,7 @@ const pageUrl = SITE.base + "/projects/" + id
 
 <style>
   .ProjectPreview {
-    --breakpoint: 500px;
+    --breakpoint: 750px;
 
     display: flex;
     justify-content: space-between;
@@ -97,6 +97,9 @@ const pageUrl = SITE.base + "/projects/" + id
     justify-content: start;
     row-gap: 0.5rem;
     margin-block-start: 0.25rem;
+  }
+  .content :global(.Tag) {
+    font-size: 0.9rem;
   }
   .ProjectPreview-thumb {
     flex-basis: calc((var(--breakpoint) - 100%) * 999);

--- a/src/components/preview/project/ProjectPreviewList.astro
+++ b/src/components/preview/project/ProjectPreviewList.astro
@@ -16,11 +16,12 @@ const { entries } = Astro.props
 <style>
   .ProjectPreviewList {
     display: grid;
-    gap: 2rem;
+    /* レイアウト最大幅(64rem)で2rem、カード内のレイアウトが1カラムに切り替わる500pxで5remになるよう、
+       画面幅が狭くなるほどgapを広げる */
+    gap: clamp(2rem, 7.863rem - 9.16vw, 5rem);
   }
   @media (max-width: 499px) {
     .ProjectPreviewList {
-      gap: 5rem;
       margin-block-start: 2rem;
     }
   }

--- a/src/components/preview/project/PublishDate.astro
+++ b/src/components/preview/project/PublishDate.astro
@@ -29,16 +29,17 @@ const year = dateObj.getFullYear().toString()
     color: light-dark(var(--gray-400), var(--gray-300));
     line-height: 1;
     font-weight: 600;
-    width: max(20%, 105px);
     height: 100%;
     position: absolute;
     top: -4rem;
     right: 0.5cqw;
+    height: fit-content;
+    align-self: start;
   }
   @media (min-width: 499px) {
     .PublishDate {
       position: relative;
-      top: 0;
+      top: -0.5rem;
       right: 0;
     }
   }


### PR DESCRIPTION
## 概要

`/projects` の各プロジェクトカードに使用技術タグ（アイコンなし）を表示するようにした。あわせてProject/Eventプレビューのレイアウトを調整。

## 変更内容

### 使用技術タグの表示
- `ProjectPreview` に既存の `TagList` を追加（description の下）。`project` コレクションのスキーマには既に `tags: reference("tag")` があり、全プロジェクトの frontmatter にタグが入っているためコンテンツ側の編集は不要
- `withIcon` を渡していないためロゴアイコンは出ない
- `TagList` は既定でモバイル時に中央寄せなので、プレビューでは常に左揃えになるよう上書き
- タグのフォントサイズを 0.9rem に

### レイアウト調整
- `ProjectPreviewList` の gap を `clamp` 化し、画面幅が狭くなるほど広がるように
- 1カラムへの切り替え幅を Project は 750px、Event は 650px に
- 日付（`PublishDate`）の幅指定をやめ、テキストとの間隔・位置を微調整

## 確認

- `yarn build` 成功（126ページ）
- `yarn astro check` は既知の `src/lib/tag.ts:16` の1件のみでエラー増加なし
- 見た目は未確認（要目視）

🤖 Generated with [Claude Code](https://claude.com/claude-code)