### PR TITLE
タグページに技術の1行説明を追加

### DIFF
--- a/src/components/pages/index/PageHeader.astro
+++ b/src/components/pages/index/PageHeader.astro
@@ -16,6 +16,7 @@ const { title, style } = Astro.props
   <p class="subtitle">
     <slot />
   </p>
+  <slot name="after-subtitle" />
 </div>
 
 <style>

--- a/src/components/pages/index/PageHeader.astro
+++ b/src/components/pages/index/PageHeader.astro
@@ -13,23 +13,15 @@ const { title, style } = Astro.props
 
 <div class="PageHeader">
   <PageTitle title={title} small={style?.title_small} />
-  <div class="subtitle-group">
-    <p class="subtitle">
-      <slot />
-    </p>
-    <slot name="after-subtitle" />
-  </div>
+  <p class="subtitle">
+    <slot />
+  </p>
 </div>
 
 <style>
   .PageHeader {
     display: grid;
     text-align: center;
-  }
-  /* subtitleとafter-subtitleスロットの間隔はこのgapで調整する */
-  .subtitle-group {
-    display: grid;
-    gap: 0.25rem;
   }
   .subtitle {
     margin: 0;

--- a/src/components/pages/index/PageHeader.astro
+++ b/src/components/pages/index/PageHeader.astro
@@ -13,10 +13,12 @@ const { title, style } = Astro.props
 
 <div class="PageHeader">
   <PageTitle title={title} small={style?.title_small} />
-  <p class="subtitle">
-    <slot />
-  </p>
-  <slot name="after-subtitle" />
+  <div class="subtitle-group">
+    <p class="subtitle">
+      <slot />
+    </p>
+    <slot name="after-subtitle" />
+  </div>
 </div>
 
 <style>
@@ -24,10 +26,15 @@ const { title, style } = Astro.props
     display: grid;
     text-align: center;
   }
+  /* subtitleとafter-subtitleスロットの間隔はこのgapで調整する */
+  .subtitle-group {
+    display: grid;
+    gap: 0.25rem;
+  }
   .subtitle {
     margin: 0;
     line-height: 1.7;
-    color: light-dark(var(--slate-500), var(--slate-200));
+    color: light-dark(var(--slate-600), var(--slate-200));
   }
 
   .subtitle :global(a) {

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -146,6 +146,7 @@ const tag = defineCollection({
   schema: () =>
     z.object({
       name: z.string(),
+      description: z.string(),
       url: z.string().url(),
       skill: z.boolean().default(true)
     })

--- a/src/content/tag.yaml
+++ b/src/content/tag.yaml
@@ -1,217 +1,288 @@
 applescript:
   name: AppleScript
+  description: macOSのアプリケーション操作を自動化するためのスクリプト言語
   url: https://developer.apple.com/library/archive/documentation/AppleScript/Conceptual/AppleScriptX/AppleScriptX.html
 astro:
   name: Astro
+  description: コンテンツ中心のWebサイトを静的に生成するWebフレームワーク
   url: https://astro.build/
 bash:
   name: Bash
+  description: UNIX系OSで標準的に使われるシェルと、そのスクリプト言語
   url: https://ja.wikipedia.org/wiki/Bash
 cf-pages:
   name: Cloudflare Pages
+  description: Cloudflareが提供する、静的サイト・フロントエンド向けのホスティングサービス
   url: https://pages.cloudflare.com/
 chroma-js:
   name: Chroma.js
+  description: 色の変換・補間・パレット生成を扱うJavaScriptライブラリ
   url: https://gka.github.io/chroma.js/
 claude-code:
   name: Claude Code
+  description: ターミナル上で動作する、Anthropic製のAIコーディングエージェント
   url: https://claude.com/claude-code
 claude-design:
   name: Claude Design
+  description: デザインシステムに沿ったUIデザインをClaudeと作れる、Anthropicのデザインツール
   url: https://claude.com/product/design
 css:
   name: CSS
+  description: Webページの見た目やレイアウトを記述するスタイルシート言語
   url: https://developer.mozilla.org/ja/docs/Web/CSS
 d3:
   name: D3.js
+  description: データからSVGなどの可視化を組み立てるJavaScriptライブラリ
   url: https://d3js.org/
 devtools:
   name: DevTools
+  description: ブラウザに内蔵された、Webページの検証やデバッグのための開発者ツール
   url: https://developer.chrome.com/docs/devtools?hl=ja
 drizzle:
   name: Drizzle
+  description: スキーマとクエリをTypeScriptで型安全に書けるORM
   url: https://orm.drizzle.team/
 excel:
   name: Excel
+  description: Microsoftの表計算ソフト
   url: https://www.microsoft.com/ja-jp/microsoft-365/excel
 git:
   name: Git
+  description: ソースコードの変更履歴を管理する分散型バージョン管理システム
   url: https://git-scm.com/
 github:
   name: GitHub
+  description: Gitリポジトリのホスティングと開発コラボレーションのためのプラットフォーム
   url: https://github.co.jp/
 glsl:
   name: GLSL
+  description: OpenGL系のシェーダを記述するためのプログラミング言語
   url: https://ja.wikipedia.org/wiki/GLSL
 graphql:
   name: GraphQL
+  description: 必要なデータだけをクライアント側から指定して取得できる、API向けのクエリ言語
   url: https://graphql.org/
 hast:
   name: hast
+  description: HTMLを抽象構文木として表現するためのデータ構造の仕様
   url: https://github.com/syntax-tree/hast
 html:
   name: HTML
+  description: Webページの構造と意味を記述するマークアップ言語
   url: https://developer.mozilla.org/ja/docs/Web/HTML
 hyperref:
   name: hyperref
+  description: LaTeX文書にハイパーリンクやしおりを追加するパッケージ
   skill: false
   url: https://texwiki.texjp.org/?hyperref
 imagemagick:
   name: ImageMagick
+  description: 画像の変換や加工をコマンドラインから行える画像処理ツール
   url: https://imagemagick.org/
 javascript:
   name: JavaScript
+  description: Webブラウザをはじめ、幅広い環境で動作するプログラミング言語
   url: https://developer.mozilla.org/ja/docs/Web/JavaScript
 jotai:
   name: Jotai
+  description: アトムという最小単位から状態を組み立てる、React向けの状態管理ライブラリ
   url: https://jotai.org/
 jquery:
   name: jQuery
+  description: DOM操作やAjaxを簡潔に書くための、定番のJavaScriptライブラリ
   url: https://jquery.com/
 laravel:
   name: Laravel
+  description: PHPのフルスタックWebアプリケーションフレームワーク
   url: https://laravel.com/
 latex:
   name: LaTeX
+  description: 論文や技術文書の組版に使われるマークアップ言語と、その組版システム
   url: https://ja.wikipedia.org/wiki/LaTeX
 mantine:
   name: Mantine
+  description: コンポーネントとフックを幅広く揃えたReact向けのUIライブラリ
   url: https://mantine.dev/
 mdsvex:
   name: mdsvex
+  description: Markdownの中でSvelteコンポーネントを使えるようにするプリプロセッサ
   url: https://mdsvex.pngwn.io/
 mdx:
   name: MDX
+  description: Markdownの中でJSXコンポーネントを使えるようにする文書フォーマット
   url: https://mdxjs.com/
 munsell:
   name: munsell
+  description: マンセル表色系と各種色空間の相互変換を行うJavaScriptライブラリ
   url: https://privet-kitty.github.io/munsell.js/modules.html
 mysql:
   name: MySQL
+  description: 世界的に広く使われているオープンソースのリレーショナルデータベース
   url: https://www.mysql.com/jp/
 postgresql:
   name: PostgreSQL
+  description: 拡張性と標準準拠を重視したオープンソースのリレーショナルデータベース
   url: https://www.postgresql.org/
 prosemirror:
   name: ProseMirror
+  description: 構造化された文書モデルの上にリッチテキストエディタを組み立てるツールキット
   url: https://prosemirror.net/
 python:
   name: Python
+  description: 簡潔な文法と豊富なライブラリで知られる汎用プログラミング言語
   url: https://www.python.org/
 react:
   name: React
+  description: 宣言的なコンポーネントでUIを構築するJavaScriptライブラリ
   url: https://ja.react.dev/
 react-router:
   name: React Router
+  description: Reactアプリケーションのルーティングを担うライブラリ
   url: https://reactrouter.com/
 rehype-pretty-code:
   name: Rehype Pretty Code
+  description: Shikiを使ってMarkdown中のコードブロックを装飾するrehypeプラグイン
   url: https://rehype-pretty.pages.dev/
 rehypejs:
   name: rehypejs
+  description: HTMLの抽象構文木を解析・変換するunifiedベースのツール群
   url: https://github.com/rehypejs/rehype
 remarkjs:
   name: remarkjs
+  description: Markdownの抽象構文木を解析・変換するunifiedベースのツール群
   url: https://github.com/remarkjs/remark
 remotion:
   name: Remotion
+  description: Reactのコンポーネントとして動画を組み立てるフレームワーク
   url: https://www.remotion.dev/
 ruby:
   name: Ruby
+  description: 書きやすさを重視して設計された動的なオブジェクト指向プログラミング言語
   url: https://www.ruby-lang.org/ja/
 rust:
   name: Rust
+  description: 所有権の仕組みでメモリ安全性を保証するシステムプログラミング言語
   url: https://www.rust-lang.org/ja
 slidev:
   name: Slidev
+  description: Markdownでスライドを書ける、Web技術ベースのプレゼンテーションツール
   url: https://sli.dev/
 starlight:
   name: Starlight
+  description: Astroでドキュメントサイトを構築するための公式テーマ
   url: https://starlight.astro.build/ja/
 storybook:
   name: Storybook
+  description: UIコンポーネントを個別に開発し、カタログとして共有するための開発ツール
   url: https://storybook.js.org/
 subfiles:
   name: subfiles
+  description: LaTeX文書を分割し、各ファイル単体でもコンパイルできるようにするパッケージ
   skill: false
   url: https://ctan.org/pkg/subfiles
 svelte:
   name: Svelte
+  description: コンパイル時にDOM操作へ変換される、実行時ランタイムの小さいUIフレームワーク
   url: https://svelte.jp/
 sveltekit:
   name: SvelteKit
+  description: Svelte公式のフルスタックWebアプリケーションフレームワーク
   url: https://svelte.jp/docs/kit/introduction
 svg:
   name: SVG
+  description: ベクター画像をXMLで記述する画像フォーマット
   url: https://developer.mozilla.org/ja/docs/Web/SVG
 svg-js:
   name: SVG.js
+  description: SVGの生成やアニメーションを扱う軽量なJavaScriptライブラリ
   url: https://svgjs.dev
 tailwind-css:
   name: Tailwind CSS
+  description: ユーティリティクラスの組み合わせでスタイルを組み立てるCSSフレームワーク
   url: https://tailwindcss.com/
 tanstack-query:
   name: TanStack Query
+  description: 非同期データの取得・キャッシュ・同期を扱うデータフェッチライブラリ
   url: https://tanstack.com/query/latest
 tcolorbox:
   name: tcolorbox
+  description: LaTeXで装飾付きのボックスを組版するパッケージ
   url: https://ctan.org/pkg/tcolorbox
 tex2img:
   name: tex2img
+  description: LaTeXのソースコードから画像を生成できるWebサービス
   skill: false
   url: https://tex2img.tech/
 threejs:
   name: Three.js
+  description: WebGLを扱いやすくする3DグラフィックスのJavaScriptライブラリ
   url: https://threejs.org/
 threlte:
   name: Threlte
+  description: Three.jsをSvelteの宣言的なコンポーネントとして扱えるようにするライブラリ
   url: https://threlte.xyz/
 tikz:
   name: TikZ
+  description: LaTeX文書の中に図を描画するためのパッケージ
   url: https://texwiki.texjp.org/TikZ
 tiptap:
   name: Tiptap
+  description: ProseMirrorをベースにしたヘッドレスなリッチテキストエディタフレームワーク
   url: https://tiptap.dev/
 typescript:
   name: TypeScript
+  description: JavaScriptに静的な型付けを加えたプログラミング言語
   url: https://www.typescriptlang.org/
 vba:
   name: VBA
+  description: Officeアプリケーションの操作を自動化するためのプログラミング言語
   url: https://ja.wikipedia.org/wiki/Visual_Basic_for_Applications
 view-transition-api:
   name: View Transition API
+  description: ページやDOMの状態変化にアニメーション付きの遷移を与えるブラウザAPI
   url: https://developer.mozilla.org/ja/docs/Web/API/View_Transition_API
 vscode:
   name: VS Code
+  description: Microsoftが開発する、拡張性の高いコードエディタ
   url: https://code.visualstudio.com/
 vuejs:
   name: Vue.js
+  description: テンプレートとリアクティビティを軸にUIを構築するJavaScriptフレームワーク
   url: https://ja.vuejs.org/
 web-speech-api:
   name: Web Speech API
+  description: 音声認識と音声合成をブラウザ上で扱うためのWeb API
   url: https://developer.mozilla.org/ja/docs/Web/API/Web_Speech_API
 webgl:
   name: WebGL
+  description: ブラウザ上でGPUを使った2D/3D描画を行うためのグラフィックスAPI
   url: https://developer.mozilla.org/ja/docs/Web/API/WebGL_API
 webgpu:
   name: WebGPU
+  description: 現代的なGPUの機能をブラウザから扱うためのグラフィックスAPI
   url: https://developer.mozilla.org/ja/docs/Web/API/WebGPU_API
 wgpu:
   name: wgpu
+  description: WebGPUの仕様に沿った、Rust製のクロスプラットフォームなグラフィックスAPI
   url: https://wgpu.rs/
 wgsl:
   name: WGSL
+  description: WebGPUのシェーダを記述するためのプログラミング言語
   url: https://www.w3.org/TR/WGSL/
 winit:
   name: winit
+  description: Rustでウィンドウの生成と入力イベントの処理を行うクロスプラットフォームなライブラリ
   url: https://github.com/rust-windowing/winit
 wordpress:
   name: WordPress
+  description: 世界的に広く使われているオープンソースのCMS
   url: https://wordpress.com/ja/
 xparse:
   name: xparse
+  description: LaTeXでコマンドの引数の受け取り方を柔軟に定義できるパッケージ
   skill: false
   url: https://ctan.org/pkg/xparse
 zod:
   name: Zod
+  description: スキーマを定義して値を検証する、TypeScript向けのバリデーションライブラリ
   url: https://zod.dev/

--- a/src/layouts/default.astro
+++ b/src/layouts/default.astro
@@ -33,12 +33,16 @@ const { content, meta, style } = Astro.props
   <Body>
     <MainLayout>
       <div class="MainLayout-inner" class:list={[{ "-title-small": style?.title_small }]}>
-        <PageHeader title={content.title} style={style}>
-          <slot name="subtitle">
-            {content.subtitle}
-          </slot>
-          <slot name="after-subtitle" slot="after-subtitle" />
-        </PageHeader>
+        {
+          /* headerスロットを渡したページは、ヘッダーのマークアップを自前で組み立てる */
+          Astro.slots.has("header") ? (
+            <slot name="header" />
+          ) : (
+            <PageHeader title={content.title} style={style}>
+              <slot name="subtitle">{content.subtitle}</slot>
+            </PageHeader>
+          )
+        }
         <div class="slot-wrapper"><slot /></div>
       </div>
     </MainLayout>

--- a/src/layouts/default.astro
+++ b/src/layouts/default.astro
@@ -37,6 +37,7 @@ const { content, meta, style } = Astro.props
           <slot name="subtitle">
             {content.subtitle}
           </slot>
+          <slot name="after-subtitle" slot="after-subtitle" />
         </PageHeader>
         <div class="slot-wrapper"><slot /></div>
       </div>

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -50,10 +50,12 @@ const linkLabel = new URL(tag.url).hostname.replace(/^www\./, "")
 <DefaultPageLayout content={{ title, subtitle }} meta={{ ...meta }}>
   <div class="tag-header" slot="header">
     <PageTitle title={tag.name} />
-    <p class="description">{tag.description}</p>
-    <a class="official-link" href={tag.url} target="_blank" rel="noopener noreferrer">
-      <span class="label">{linkLabel}</span>
-    </a>
+    <div class="description-group">
+      <p class="description">{tag.description}</p>
+      <a class="official-link" href={tag.url} target="_blank" rel="noopener noreferrer">
+        <span class="label">{linkLabel}</span>
+      </a>
+    </div>
   </div>
   <div class="content">
     <ArticlePreviewList entries={articles} />
@@ -69,6 +71,12 @@ const linkLabel = new URL(tag.url).hostname.replace(/^www\./, "")
     place-items: center;
     container-type: inline-size;
   }
+  /* 説明とリンクの間隔はこのgapで調整する */
+  .description-group {
+    display: grid;
+    place-items: center;
+    gap: 0.25rem;
+  }
   .description {
     margin: 0;
     line-height: 1.7;
@@ -83,7 +91,7 @@ const linkLabel = new URL(tag.url).hostname.replace(/^www\./, "")
     display: flex;
     align-items: center;
     gap: 0.25rem;
-    color: light-dark(var(--slate-500), var(--slate-400));
+    color: light-dark(var(--slate-500), var(--slate-300));
     text-decoration: none;
     font-size: 1.1rem;
   }

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -4,6 +4,7 @@ import DefaultPageLayout from "$/layouts/default.astro"
 import { compareDateForSort } from "$/lib/sort"
 import type { GetStaticPaths } from "astro"
 import ArticlePreviewList from "$components/preview/tag/ArticlePreviewList.astro"
+import PageTitle from "$components/pages/index/PageTitle.astro"
 import { collectTagIds, getRefTagCollection, filterByTag } from "$/lib/tag"
 import { getCollection } from "astro:content"
 import { makeEntryMap, type TechNotComingSoon } from "$/lib/collection"
@@ -47,13 +48,34 @@ const linkLabel = new URL(tag.url).hostname.replace(/^www\./, "")
 ---
 
 <DefaultPageLayout content={{ title, subtitle }} meta={{ ...meta }}>
-  <a class="official-link" slot="after-subtitle" href={tag.url} target="_blank" rel="noopener noreferrer">
-    <span class="label">{linkLabel}</span>
-  </a>
-  <ArticlePreviewList entries={articles} />
+  <div class="tag-header" slot="header">
+    <PageTitle title={tag.name} />
+    <p class="description">{tag.description}</p>
+    <a class="official-link" href={tag.url} target="_blank" rel="noopener noreferrer">
+      <span class="label">{linkLabel}</span>
+    </a>
+  </div>
+  <div class="content">
+    <ArticlePreviewList entries={articles} />
+  </div>
 </DefaultPageLayout>
 
 <style>
+  /* タイトル・説明・リンクの間隔はこのgapで調整する */
+  .tag-header {
+    display: grid;
+    gap: 0.25rem;
+    text-align: center;
+    place-items: center;
+    container-type: inline-size;
+  }
+  .description {
+    margin: 0;
+    line-height: 1.7;
+    color: light-dark(var(--slate-600), var(--slate-200));
+    max-width: 80cqw;
+    word-break: auto-phrase;
+  }
   a.official-link,
   a.official-link:visited {
     justify-self: center;

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -4,7 +4,6 @@ import DefaultPageLayout from "$/layouts/default.astro"
 import { compareDateForSort } from "$/lib/sort"
 import type { GetStaticPaths } from "astro"
 import ArticlePreviewList from "$components/preview/tag/ArticlePreviewList.astro"
-import { Icon } from "astro-icon/components"
 import { collectTagIds, getRefTagCollection, filterByTag } from "$/lib/tag"
 import { getCollection } from "astro:content"
 import { makeEntryMap, type TechNotComingSoon } from "$/lib/collection"
@@ -50,29 +49,33 @@ const linkLabel = new URL(tag.url).hostname.replace(/^www\./, "")
 <DefaultPageLayout content={{ title, subtitle }} meta={{ ...meta }}>
   <a class="official-link" slot="after-subtitle" href={tag.url} target="_blank" rel="noopener noreferrer">
     <span class="label">{linkLabel}</span>
-    <Icon name="iconamoon:arrow-top-right-3-square-thin" size={14} stroke-width={1.5} aria-hidden="true" />
   </a>
   <ArticlePreviewList entries={articles} />
 </DefaultPageLayout>
 
 <style>
-  .official-link {
+  a.official-link,
+  a.official-link:visited {
     justify-self: center;
     margin-block-start: 0.875rem;
+    /* 外部リンクアイコンはglobal.cssの a[target="_blank"]::after が付ける */
     display: flex;
     align-items: center;
     gap: 0.25rem;
     font-size: 0.8125rem;
-    color: light-dark(var(--slate-500), var(--slate-400));
+    /* PageHeaderのリンクに合わせて、light-dark()の中は変数ではなくリテラルで書く */
+    color: #64748b;
+    color: light-dark(#64748b, #94a3b8);
     text-decoration: none;
   }
-  .official-link .label {
+  a.official-link .label {
     text-decoration: underline;
     text-decoration-thickness: 1px;
     text-decoration-style: dotted;
     text-underline-offset: 0.25rem;
   }
-  .official-link:hover {
-    color: light-dark(var(--slate-400), var(--slate-300));
+  a.official-link:hover {
+    color: #94a3b8;
+    color: light-dark(#94a3b8, #cbd5e1);
   }
 </style>

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -51,6 +51,19 @@ const subtitleHtml = marked.parseInline(subtitleMd, { renderer })
 ---
 
 <DefaultPageLayout content={{ title, subtitle }} meta={{ ...meta }}>
-  <Fragment slot="subtitle" set:html={subtitleHtml} />
+  <Fragment slot="subtitle">
+    <span set:html={subtitleHtml} />
+    <span class="tag-description">{tag.description}</span>
+  </Fragment>
   <ArticlePreviewList entries={articles} />
 </DefaultPageLayout>
+
+<style>
+  .tag-description {
+    display: block;
+    margin-block-start: 0.5rem;
+    font-size: 0.875rem;
+    line-height: 1.6;
+    color: light-dark(var(--slate-500), var(--slate-300));
+  }
+</style>

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -79,9 +79,11 @@ const linkLabel = new URL(tag.url).hostname.replace(/^www\./, "")
   }
   .description {
     margin: 0;
+    /* 375px以下で14px、768px以上で16px */
+    font-size: clamp(0.875rem, 0.756rem + 0.509vw, 1rem);
     line-height: 1.7;
     color: light-dark(var(--slate-600), var(--slate-200));
-    max-width: 80cqw;
+    max-width: min(clamp(80cqw, 74.4cqw + 3.34rem, 90cqw), 32em);
     word-break: auto-phrase;
   }
   a.official-link,

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -57,16 +57,13 @@ const linkLabel = new URL(tag.url).hostname.replace(/^www\./, "")
   a.official-link,
   a.official-link:visited {
     justify-self: center;
-    margin-block-start: 0.875rem;
     /* 外部リンクアイコンはglobal.cssの a[target="_blank"]::after が付ける */
     display: flex;
     align-items: center;
     gap: 0.25rem;
-    font-size: 0.8125rem;
-    /* PageHeaderのリンクに合わせて、light-dark()の中は変数ではなくリテラルで書く */
-    color: #64748b;
-    color: light-dark(#64748b, #94a3b8);
+    color: light-dark(var(--slate-500), var(--slate-400));
     text-decoration: none;
+    font-size: 1.1rem;
   }
   a.official-link .label {
     text-decoration: underline;
@@ -75,7 +72,6 @@ const linkLabel = new URL(tag.url).hostname.replace(/^www\./, "")
     text-underline-offset: 0.25rem;
   }
   a.official-link:hover {
-    color: #94a3b8;
-    color: light-dark(#94a3b8, #cbd5e1);
+    color: light-dark(var(--slate-400), var(--slate-300));
   }
 </style>

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -4,9 +4,8 @@ import DefaultPageLayout from "$/layouts/default.astro"
 import { compareDateForSort } from "$/lib/sort"
 import type { GetStaticPaths } from "astro"
 import ArticlePreviewList from "$components/preview/tag/ArticlePreviewList.astro"
-import { marked } from "marked"
+import { Icon } from "astro-icon/components"
 import { collectTagIds, getRefTagCollection, filterByTag } from "$/lib/tag"
-import { setExternalLinkRenderer } from "$/lib/marked"
 import { getCollection } from "astro:content"
 import { makeEntryMap, type TechNotComingSoon } from "$/lib/collection"
 
@@ -38,32 +37,42 @@ interface Props {
 const { articles, tag } = Astro.props
 
 const title = tag.name
-const subtitle = `${tag.name}を扱った作品や記事`
+const subtitle = tag.description
 const meta = {
+  description: `${tag.name}を扱った作品や記事｜${tag.description}`,
   ogimage: `/og/default.png`
 }
 
-const renderer = new marked.Renderer()
-setExternalLinkRenderer(renderer)
-
-const subtitleMd = `[${tag.name}](${tag.url})を扱った作品や記事`
-const subtitleHtml = marked.parseInline(subtitleMd, { renderer })
+// リンク先はMDNやWikipediaなど様々なので、行き先が分かるようにホスト名をラベルにする
+const linkLabel = new URL(tag.url).hostname.replace(/^www\./, "")
 ---
 
 <DefaultPageLayout content={{ title, subtitle }} meta={{ ...meta }}>
-  <Fragment slot="subtitle">
-    <span set:html={subtitleHtml} />
-    <span class="tag-description">{tag.description}</span>
-  </Fragment>
+  <a class="official-link" slot="after-subtitle" href={tag.url} target="_blank" rel="noopener noreferrer">
+    <span class="label">{linkLabel}</span>
+    <Icon name="iconamoon:arrow-top-right-3-square-thin" size={14} stroke-width={1.5} aria-hidden="true" />
+  </a>
   <ArticlePreviewList entries={articles} />
 </DefaultPageLayout>
 
 <style>
-  .tag-description {
-    display: block;
-    margin-block-start: 0.5rem;
-    font-size: 0.875rem;
-    line-height: 1.6;
-    color: light-dark(var(--slate-500), var(--slate-300));
+  .official-link {
+    justify-self: center;
+    margin-block-start: 0.875rem;
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    font-size: 0.8125rem;
+    color: light-dark(var(--slate-500), var(--slate-400));
+    text-decoration: none;
+  }
+  .official-link .label {
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-decoration-style: dotted;
+    text-underline-offset: 0.25rem;
+  }
+  .official-link:hover {
+    color: light-dark(var(--slate-400), var(--slate-300));
   }
 </style>


### PR DESCRIPTION
## 概要

`/tags/*` ページに、その技術が何なのかを1行で説明する文を追加した。

あわせてヘッダーの構成を見直し、冗長だった「〜を扱った作品や記事」の行を削除して、説明文をその位置に昇格させた。技術名（h1）はリンクにせず、公式サイトへのリンクは説明の下に小さく独立させている。

```
                    WebGPU
現代的なGPUの機能をブラウザから扱うためのグラフィックスAPI
             developer.mozilla.org ↗
```

## 変更内容

### tagコレクションに `description` を追加

- `src/content.config.ts` — スキーマに `description: z.string()` を必須項目として追加
- `src/content/tag.yaml` — 全71タグに1行の説明を記述

必須にしているので、新しいタグを追加して説明を書き忘れるとビルドが落ちる。

### タグページのヘッダーをページ側で組み立てる

- `src/layouts/default.astro` — `header` スロットを追加し、渡された場合は `PageHeader` の代わりにそちらを描画する
- `src/pages/tags/[tag].astro` — `PageTitle` を直接使ってヘッダーを構築。囲みのdiv・余白・文字色がすべてページ側で完結し、他ページには影響しない

公式リンクのラベルはホスト名（`developer.mozilla.org` など）。リンク先がMDN・Wikipedia・公式サイトと様々なため、「公式サイト」固定のラベルにはしていない。外部リンクアイコンは `global.css` の `a[target="_blank"]::after` が付与する。

### 説明文のレスポンシブ対応

狭い画面で3行になってしまうため、文字サイズを14px〜16pxで可変にし、幅は狭い画面ほどコンテナに対する比率が上がるようにした（広い画面では行長が伸びすぎないよう32emで頭打ち）。

`meta` の description は `WebGPUを扱った作品や記事｜現代的なGPUの機能を…` のように、ページの内容と技術の説明の両方が入るよう明示している。

## 確認

- `yarn build` — 140ページ成功。タグページ・他ページのHTML出力を確認
- `yarn astro check` — エラーは既知の `src/lib/tag.ts:16` の1件のみ（本PRとは無関係）
- prettier チェック通過

## 備考

- 320px程度の画面幅では、最長の説明（`winit`）だけ3行のままです。14pxを下限とする以上、文言を短くする以外の解決策がありません
- 説明の文言で気になるものがあれば直します（`claude-design` / `hast` / `munsell` あたりは表現に幅があります）

🤖 Generated with [Claude Code](https://claude.com/claude-code)