### PR TITLE
feat: tech・events一覧ページの各アイテムにタグを表示

### DIFF
--- a/src/components/preview/event/EventPreveiw.astro
+++ b/src/components/preview/event/EventPreveiw.astro
@@ -2,6 +2,7 @@
 import type { CollectionEntry } from "astro:content"
 import { Image } from "astro:assets"
 import PublishDate from "./PublishDate.astro"
+import TagList from "$components/article-header/TagList.astro"
 import { SITE } from "$/config"
 import { Icon } from "astro-icon/components"
 
@@ -27,6 +28,7 @@ const pageUrl = SITE.base + "/events/" + id
         <p class="desc">
           {event.description}
         </p>
+        {event.tags.length > 0 && <TagList tags={event.tags} />}
       </div>
     </div>
   </div>
@@ -95,6 +97,15 @@ const pageUrl = SITE.base + "/events/" + id
     line-height: 1.5rem;
     hyphens: auto;
     color: light-dark(var(--slate-800), white);
+  }
+  /* TagListは既定で中央寄せだが、プレビューのテキストは常に左揃えなので合わせる */
+  .content :global(.TagList) {
+    justify-content: start;
+    row-gap: 0.5rem;
+    margin-block-start: 0.25rem;
+  }
+  .content :global(.Tag) {
+    font-size: 0.9rem;
   }
   .EventPreview-thumb {
     flex-basis: calc((var(--breakpoint) - 100%) * 999);

--- a/src/components/preview/tech/TechPreview.astro
+++ b/src/components/preview/tech/TechPreview.astro
@@ -1,5 +1,6 @@
 ---
 import PublishDate from "./PublishDate.astro"
+import TagList from "$components/article-header/TagList.astro"
 import { SITE } from "$/config"
 import { getEntry } from "astro:content"
 import { Icon } from "astro-icon/components"
@@ -37,6 +38,7 @@ const series = tech.series ? await getEntry("series", tech.series.id) : null
         <p class="desc">
           {tech.description}
         </p>
+        {tech.tags.length > 0 && <TagList tags={tech.tags} />}
       </div>
     </div>
   </div>
@@ -167,6 +169,19 @@ const series = tech.series ? await getEntry("series", tech.series.id) : null
     hyphens: auto;
     word-break: auto-phrase;
     color: light-dark(var(--slate-800), white);
+  }
+  .content :global(.TagList) {
+    row-gap: 0.5rem;
+    margin-block-start: 0.25rem;
+  }
+  /* TagListは768px未満で中央寄せだが、.contentのテキストは500px以上で左揃えになるので合わせる */
+  @media (min-width: 500px) {
+    .content :global(.TagList) {
+      justify-content: start;
+    }
+  }
+  .content :global(.Tag) {
+    font-size: 0.9rem;
   }
 
   /* .contentがz-index: 2のため、ピンアイコンがその下に隠れないようにする */

--- a/src/components/preview/tech/TechPreview.astro
+++ b/src/components/preview/tech/TechPreview.astro
@@ -60,7 +60,7 @@ const series = tech.series ? await getEntry("series", tech.series.id) : null
   .inner {
     display: grid;
     justify-items: start;
-    align-items: center;
+    align-items: start;
     column-gap: 0.75rem;
     width: 100%;
   }
@@ -190,7 +190,6 @@ const series = tech.series ? await getEntry("series", tech.series.id) : null
   }
 
   .-pinned:not(:has(+ .-pinned)) {
-    margin-block-end: 1rem;
     padding-block-end: 2rem;
   }
 

--- a/src/components/preview/tech/TechPreviewList.astro
+++ b/src/components/preview/tech/TechPreviewList.astro
@@ -18,4 +18,10 @@ const { entries } = Astro.props
     display: grid;
     gap: 1rem;
   }
+
+  @media (min-width: 500px) {
+    .TechPreviewList {
+      gap: 2rem;
+    }
+  }
 </style>


### PR DESCRIPTION
## 概要

projects一覧ページと同様に、tech一覧ページとevents一覧ページの各プレビューにもタグを表示するようにしました。

## 変更内容

- `TechPreview.astro` / `EventPreveiw.astro` に `TagList` を追加（説明文の下に配置）
  - タグ0件の記事で余分な `gap` が入らないよう `tags.length > 0` でガード
  - スタイルは `ProjectPreveiw.astro` に合わせて左寄せ・`.Tag` は `0.9rem`
  - tech側は500px未満で `.content` 自体が中央寄せになるため、左寄せの上書きは500px以上に限定
- タグ追加でcontentが高くなり、プレビュー間の余白が画面幅で変動していたため、`TechPreview` の `.inner` を `align-items: start` に変更し、`TechPreviewList` 側で余白を調整

いずれもスキーマに既存の `tags: z.array(reference("tag"))` を表示するだけで、コンテンツ側の変更はありません。

## 確認

- `yarn astro check` → 既知の `src/lib/tag.ts:16` の1件のみ（本変更とは無関係）
- 見た目の確認はプレビューデプロイでお願いします

🤖 Generated with [Claude Code](https://claude.com/claude-code)