### PR TITLE
feat: トップページのSkill Tagをカテゴリごとに分けて表示

### DIFF
--- a/src/components/pages/index/TagsList.astro
+++ b/src/components/pages/index/TagsList.astro
@@ -37,34 +37,31 @@ const categories = [...tagsByCategory.entries()]
 </div>
 
 <style>
-  /* 件数順に読むリストではなく「守備範囲の広さ」を見せる塊として扱うため、
-     中央寄せにしたうえで、親セクションのpadding-inlineを打ち消して見出しより広い帯にする */
   .TagsList {
     display: grid;
     gap: 2rem;
-    margin-inline: calc(var(--section-padding-inline, 0px) * -1);
   }
 
   .category {
     display: grid;
-    gap: 0.75rem;
+    justify-items: flex-start;
+    gap: 1rem;
   }
 
   /* 帯の塊を区切るラベルであって読ませる見出しではないため、proseのh3より控えめに寄せる */
   .label {
     margin: 0;
     text-align: center;
-    font-size: 0.875rem;
-    font-weight: 600;
-    letter-spacing: 0.08em;
+    font-size: 1.1rem;
+    font-weight: 400;
     color: light-dark(var(--slate-500), var(--slate-300));
+    font-family: "Ubuntu Mono";
   }
 
   .tags {
     display: flex;
     list-style-type: none;
     flex-wrap: wrap;
-    justify-content: center;
     gap: clamp(0.5rem, 0.356rem + 0.616vw, 0.75rem);
     margin-block: 0;
     padding: 0;

--- a/src/components/pages/index/TagsList.astro
+++ b/src/components/pages/index/TagsList.astro
@@ -82,9 +82,9 @@ const categories = [...tagsByCategory.entries()]
   .tags :global(.Tag) {
     border-radius: 0;
     display: flex;
-    /* 320px:12px -> 375px:13px -> 1024px:16px の2区間。
+    /* 320px:12px -> 375px:14px -> 1024px:16px の2区間。
        min()は、傾きの急な前半の式が375pxを境に後半の式を追い越すことを利用した切り替え */
-    font-size: clamp(0.75rem, min(0.386rem + 1.818vw, 0.704rem + 0.462vw), 1rem);
+    font-size: clamp(0.75rem, min(0.023rem + 3.636vw, 0.803rem + 0.308vw), 1rem);
     line-height: 1;
     gap: 0.5rem;
     align-items: center;

--- a/src/components/pages/index/TagsList.astro
+++ b/src/components/pages/index/TagsList.astro
@@ -1,36 +1,72 @@
 ---
 import TagLink from "$components/tag/TagLink.astro"
-import { collectTagIdsWithCount, getRefTagCollection, getSkillTag } from "$/lib/tag"
+import { collectTagIdsWithCount, getRefTagCollection, getSkillTagCategoryMap } from "$/lib/tag"
+import { SKILL_CATEGORY_META } from "$/config"
 
 const targets = await getRefTagCollection()
-const skills = new Set(await getSkillTag())
+const categoryOf = await getSkillTagCategoryMap()
 
 const tags = collectTagIdsWithCount(targets)
-  .filter((tag) => skills.has(tag.id))
+  .filter((tag) => categoryOf.has(tag.id))
   .sort((a, b) => b.count - a.count || a.id.localeCompare(b.id))
+
+/* 件数降順に並べたtagsをそのまま流し込むので、各カテゴリ内の並び順もその順序を引き継ぐ */
+const tagsByCategory = Map.groupBy(tags, (tag) => categoryOf.get(tag.id)!)
+
+/* カテゴリの表示順は、そのカテゴリに属するタグの件数の合計が多い順 */
+const categories = [...tagsByCategory.entries()]
+  .map(([category, tags]) => ({ category, tags, total: tags.reduce((sum, tag) => sum + tag.count, 0) }))
+  .sort((a, b) => b.total - a.total)
 ---
 
-<ul class="TagsList">
+<div class="TagsList">
   {
-    tags.map((tag) => (
-      <li>
-        <TagLink tagId={tag.id} count={tag.count} withIcon />
-      </li>
+    categories.map(({ category, tags }) => (
+      <section class="category">
+        <h3 class="label">{SKILL_CATEGORY_META[category].label}</h3>
+        <ul class="tags">
+          {tags.map((tag) => (
+            <li>
+              <TagLink tagId={tag.id} count={tag.count} withIcon />
+            </li>
+          ))}
+        </ul>
+      </section>
     ))
   }
-</ul>
+</div>
 
 <style>
   /* 件数順に読むリストではなく「守備範囲の広さ」を見せる塊として扱うため、
      中央寄せにしたうえで、親セクションのpadding-inlineを打ち消して見出しより広い帯にする */
   .TagsList {
+    display: grid;
+    gap: 2rem;
+    margin-inline: calc(var(--section-padding-inline, 0px) * -1);
+  }
+
+  .category {
+    display: grid;
+    gap: 0.75rem;
+  }
+
+  /* 帯の塊を区切るラベルであって読ませる見出しではないため、proseのh3より控えめに寄せる */
+  .label {
+    margin: 0;
+    text-align: center;
+    font-size: 0.875rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    color: light-dark(var(--slate-500), var(--slate-300));
+  }
+
+  .tags {
     display: flex;
     list-style-type: none;
     flex-wrap: wrap;
     justify-content: center;
     gap: clamp(0.5rem, 0.356rem + 0.616vw, 0.75rem);
     margin-block: 0;
-    margin-inline: calc(var(--section-padding-inline, 0px) * -1);
     padding: 0;
   }
 </style>

--- a/src/components/pages/index/TagsList.astro
+++ b/src/components/pages/index/TagsList.astro
@@ -52,18 +52,51 @@ const categories = [...tagsByCategory.entries()]
   .label {
     margin: 0;
     text-align: center;
-    font-size: 1.1rem;
+    font-size: 1.075rem;
     font-weight: 400;
     color: light-dark(var(--slate-500), var(--slate-300));
     font-family: "Ubuntu Mono";
   }
 
   .tags {
-    display: flex;
+    /* auto-fillの列数はgapとあわせてこの下限から決まるため、calcで参照できるよう変数にしておく */
+    --tags-gap: clamp(0.5rem, 0.356rem + 0.616vw, 0.75rem);
+
+    /* 列幅の下限を180pxと「gapを除いた半分の幅」の小さいほうにすることで、
+       狭い画面でも1列に落ちず、最低2カラムを保つ */
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(min(180px, (100% - var(--tags-gap)) / 2), min-content));
+    /* .categoryのjustify-itemsで内容幅に縮むと、auto-fillの列数が決まらないため幅を明示する */
+    width: 100%;
     list-style-type: none;
-    flex-wrap: wrap;
-    gap: clamp(0.5rem, 0.356rem + 0.616vw, 0.75rem);
+    gap: var(--tags-gap);
     margin-block: 0;
     padding: 0;
+  }
+
+  /* 帯の幅をセルいっぱいに伸ばして、行と列のそろった塊として見せる */
+  .tags li {
+    display: grid;
+  }
+
+  .tags :global(.Tag) {
+    border-radius: 0;
+    display: flex;
+    /* 320px:12px -> 375px:13px -> 1024px:16px の2区間。
+       min()は、傾きの急な前半の式が375pxを境に後半の式を追い越すことを利用した切り替え */
+    font-size: clamp(0.75rem, min(0.386rem + 1.818vw, 0.704rem + 0.462vw), 1rem);
+    line-height: 1;
+    gap: 0.5rem;
+    align-items: center;
+    padding-block: 6px;
+    padding-inline: 12px;
+    justify-content: flex-start;
+  }
+  .tags :global(.Tag .count) {
+    margin-inline-start: auto;
+  }
+  .tags :global(.Tag .logo) {
+    max-width: 1.25em;
+    width: 100%;
   }
 </style>

--- a/src/components/tag/TagLink.astro
+++ b/src/components/tag/TagLink.astro
@@ -76,7 +76,9 @@ const icon = withIcon ? getTagIcon(tagId) : undefined
   }
 
   .count {
+    font-family: "Ubuntu Mono";
     font-size: 0.75em;
+    white-space: nowrap;
     color: light-dark(var(--slate-500), var(--slate-300));
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,13 +30,13 @@ export const CATEGORY_META = {
 /* トップページのSkill Tagをまとめる単位。
    「その技術を何に使うか」で寄せているため、glsl/wgslは言語ではなくgraphics、sqlはdataに属する */
 export const SKILL_CATEGORY_META = {
-  language: { label: "言語" },
-  "web-platform": { label: "Webの土台" },
-  "ui-framework": { label: "UIフレームワーク" },
-  graphics: { label: "グラフィックス・ビジュアル" },
-  data: { label: "データ" },
-  authoring: { label: "文書・コンテンツ制作" },
-  tooling: { label: "開発環境・ツール" }
+  language: { label: "Languages" },
+  "web-platform": { label: "Web Platform" },
+  "ui-framework": { label: "UI Frameworks" },
+  graphics: { label: "Graphics & Visuals" },
+  data: { label: "Data" },
+  authoring: { label: "Content Authoring" },
+  tooling: { label: "Tooling" }
 }
 
 export const SKILL_CATEGORY_KEYS = Object.keys(SKILL_CATEGORY_META) as [SkillCategory, ...SkillCategory[]]

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,6 +27,22 @@ export const CATEGORY_META = {
   }
 }
 
+/* トップページのSkill Tagをまとめる単位。
+   「その技術を何に使うか」で寄せているため、glsl/wgslは言語ではなくgraphics、sqlはdataに属する */
+export const SKILL_CATEGORY_META = {
+  language: { label: "言語" },
+  "web-platform": { label: "Webの土台" },
+  "ui-framework": { label: "UIフレームワーク" },
+  graphics: { label: "グラフィックス・ビジュアル" },
+  data: { label: "データ" },
+  authoring: { label: "文書・コンテンツ制作" },
+  tooling: { label: "開発環境・ツール" }
+}
+
+export const SKILL_CATEGORY_KEYS = Object.keys(SKILL_CATEGORY_META) as [SkillCategory, ...SkillCategory[]]
+
+export type SkillCategory = keyof typeof SKILL_CATEGORY_META
+
 export const NAV_ITEMS: NavItems = {
   about: {
     path: "/",

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,6 +1,6 @@
 import { defineCollection, reference, z } from "astro:content"
 import { file, glob } from "astro/loaders"
-import { COMING_SOON_KEY } from "./config"
+import { COMING_SOON_KEY, SKILL_CATEGORY_KEYS } from "./config"
 
 const passion = defineCollection({
   loader: glob({ pattern: "**/*.mdx", base: "./src/content/passion" }),
@@ -148,7 +148,8 @@ const tag = defineCollection({
       name: z.string(),
       description: z.string(),
       url: z.string().url(),
-      skill: z.boolean().default(true)
+      skill: z.boolean().default(true),
+      category: z.enum(SKILL_CATEGORY_KEYS)
     })
 })
 

--- a/src/content/tag.yaml
+++ b/src/content/tag.yaml
@@ -1,300 +1,374 @@
 applescript:
   name: AppleScript
   description: macOSのアプリケーション操作を自動化するためのスクリプト言語
+  category: language
   url: https://developer.apple.com/library/archive/documentation/AppleScript/Conceptual/AppleScriptX/AppleScriptX.html
 astro:
   name: Astro
   description: コンテンツ中心のWebサイトを静的に生成するWebフレームワーク
+  category: ui-framework
   url: https://astro.build/
 bash:
   name: Bash
   description: UNIX系OSで標準的に使われるシェルと、そのスクリプト言語
+  category: language
   url: https://ja.wikipedia.org/wiki/Bash
 cf-pages:
   name: Cloudflare Pages
   description: Cloudflareが提供する、静的サイト・フロントエンド向けのホスティングサービス
+  category: tooling
   url: https://pages.cloudflare.com/
 chroma-js:
   name: Chroma.js
   description: 色の変換・補間・パレット生成を扱うJavaScriptライブラリ
+  category: graphics
   url: https://gka.github.io/chroma.js/
 claude-code:
   name: Claude Code
   description: ターミナル上で動作する、Anthropic製のAIコーディングエージェント
+  category: tooling
   url: https://claude.com/claude-code
 claude-design:
   name: Claude Design
   description: デザインシステムに沿ったUIデザインをClaudeと作れる、Anthropicのデザインツール
+  category: tooling
   url: https://claude.com/product/design
 css:
   name: CSS
   description: Webページの見た目やレイアウトを記述するスタイルシート言語
+  category: web-platform
   url: https://developer.mozilla.org/ja/docs/Web/CSS
 d3:
   name: D3.js
   description: データからSVGなどの可視化を組み立てるJavaScriptライブラリ
+  category: graphics
   url: https://d3js.org/
 devtools:
   name: DevTools
   description: ブラウザに内蔵された、Webページの検証やデバッグのための開発者ツール
+  category: web-platform
   url: https://developer.chrome.com/docs/devtools?hl=ja
 drizzle:
   name: Drizzle
   description: スキーマとクエリをTypeScriptで型安全に書けるORM
+  category: data
   url: https://orm.drizzle.team/
 excel:
   name: Excel
   description: Microsoftの表計算ソフト
+  category: authoring
   url: https://www.microsoft.com/ja-jp/microsoft-365/excel
 git:
   name: Git
   description: ソースコードの変更履歴を管理する分散型バージョン管理システム
+  category: tooling
   url: https://git-scm.com/
 github:
   name: GitHub
   description: Gitリポジトリのホスティングと開発コラボレーションのためのプラットフォーム
+  category: tooling
   url: https://github.co.jp/
 glsl:
   name: GLSL
   description: OpenGL系のシェーダを記述するためのプログラミング言語
+  category: graphics
   url: https://ja.wikipedia.org/wiki/GLSL
 graphql:
   name: GraphQL
   description: 必要なデータだけをクライアント側から指定して取得できる、API向けのクエリ言語
+  category: data
   url: https://graphql.org/
 hast:
   name: hast
   description: HTMLを抽象構文木として表現するためのデータ構造の仕様
+  category: authoring
   url: https://github.com/syntax-tree/hast
 html:
   name: HTML
   description: Webページの構造と意味を記述するマークアップ言語
+  category: web-platform
   url: https://developer.mozilla.org/ja/docs/Web/HTML
 hyperref:
   name: hyperref
   description: LaTeX文書にハイパーリンクやしおりを追加するパッケージ
+  category: authoring
   skill: false
   url: https://texwiki.texjp.org/?hyperref
 imagemagick:
   name: ImageMagick
   description: 画像の変換や加工をコマンドラインから行える画像処理ツール
+  category: authoring
   url: https://imagemagick.org/
 javascript:
   name: JavaScript
   description: Webブラウザをはじめ、幅広い環境で動作するプログラミング言語
+  category: language
   url: https://developer.mozilla.org/ja/docs/Web/JavaScript
 jotai:
   name: Jotai
   description: アトムという最小単位から状態を組み立てる、React向けの状態管理ライブラリ
+  category: ui-framework
   url: https://jotai.org/
 jquery:
   name: jQuery
   description: DOM操作やAjaxを簡潔に書くための、定番のJavaScriptライブラリ
+  category: ui-framework
   url: https://jquery.com/
 laravel:
   name: Laravel
   description: PHPのフルスタックWebアプリケーションフレームワーク
+  category: ui-framework
   url: https://laravel.com/
 latex:
   name: LaTeX
   description: 論文や技術文書の組版に使われるマークアップ言語と、その組版システム
+  category: authoring
   url: https://ja.wikipedia.org/wiki/LaTeX
 mantine:
   name: Mantine
   description: コンポーネントとフックを幅広く揃えたReact向けのUIライブラリ
+  category: ui-framework
   url: https://mantine.dev/
 mdsvex:
   name: mdsvex
   description: Markdownの中でSvelteコンポーネントを使えるようにするプリプロセッサ
+  category: authoring
   url: https://mdsvex.pngwn.io/
 mdx:
   name: MDX
   description: Markdownの中でJSXコンポーネントを使えるようにする文書フォーマット
+  category: authoring
   url: https://mdxjs.com/
 munsell:
   name: munsell
   description: マンセル表色系と各種色空間の相互変換を行うJavaScriptライブラリ
+  category: graphics
   url: https://privet-kitty.github.io/munsell.js/modules.html
 mysql:
   name: MySQL
   description: 世界的に広く使われているオープンソースのリレーショナルデータベース
+  category: data
   url: https://www.mysql.com/jp/
 playwright:
   name: Playwright
   description: 複数のブラウザを自動操作してテストを実行するフレームワーク
+  category: tooling
   url: https://playwright.dev/
 postgresql:
   name: PostgreSQL
   description: 拡張性と標準準拠を重視したオープンソースのリレーショナルデータベース
+  category: data
   url: https://www.postgresql.org/
 prosemirror:
   name: ProseMirror
   description: 構造化された文書モデルの上にリッチテキストエディタを組み立てるツールキット
+  category: authoring
   url: https://prosemirror.net/
 python:
   name: Python
   description: 簡潔な文法と豊富なライブラリで知られる汎用プログラミング言語
+  category: language
   url: https://www.python.org/
 react:
   name: React
   description: 宣言的なコンポーネントでUIを構築するJavaScriptライブラリ
+  category: ui-framework
   url: https://ja.react.dev/
 react-router:
   name: React Router
   description: Reactアプリケーションのルーティングを担うライブラリ
+  category: ui-framework
   url: https://reactrouter.com/
 rehype-pretty-code:
   name: Rehype Pretty Code
   description: Shikiを使ってMarkdown中のコードブロックを装飾するrehypeプラグイン
+  category: authoring
   url: https://rehype-pretty.pages.dev/
 rehypejs:
   name: rehypejs
   description: HTMLの抽象構文木を解析・変換するunifiedベースのツール群
+  category: authoring
   url: https://github.com/rehypejs/rehype
 remarkjs:
   name: remarkjs
   description: Markdownの抽象構文木を解析・変換するunifiedベースのツール群
+  category: authoring
   url: https://github.com/remarkjs/remark
 remotion:
   name: Remotion
   description: Reactのコンポーネントとして動画を組み立てるフレームワーク
+  category: graphics
   url: https://www.remotion.dev/
 ruby:
   name: Ruby
   description: 書きやすさを重視して設計された動的なオブジェクト指向プログラミング言語
+  category: language
   url: https://www.ruby-lang.org/ja/
 rust:
   name: Rust
   description: 所有権の仕組みでメモリ安全性を保証するシステムプログラミング言語
+  category: language
   url: https://www.rust-lang.org/ja
 slidev:
   name: Slidev
   description: Markdownでスライドを書ける、Web技術ベースのプレゼンテーションツール
+  category: authoring
   url: https://sli.dev/
 sql:
   name: SQL
   description: リレーショナルデータベースのデータを定義・操作するための問い合わせ言語
+  category: data
   url: https://ja.wikipedia.org/wiki/SQL
 starlight:
   name: Starlight
   description: Astroでドキュメントサイトを構築するための公式テーマ
+  category: ui-framework
   url: https://starlight.astro.build/ja/
 storybook:
   name: Storybook
   description: UIコンポーネントを個別に開発し、カタログとして共有するための開発ツール
+  category: tooling
   url: https://storybook.js.org/
 subfiles:
   name: subfiles
   description: LaTeX文書を分割し、各ファイル単体でもコンパイルできるようにするパッケージ
+  category: authoring
   skill: false
   url: https://ctan.org/pkg/subfiles
 svelte:
   name: Svelte
   description: コンパイル時にDOM操作へ変換される、実行時ランタイムの小さいUIフレームワーク
+  category: ui-framework
   url: https://svelte.jp/
 sveltekit:
   name: SvelteKit
   description: Svelte公式のフルスタックWebアプリケーションフレームワーク
+  category: ui-framework
   url: https://svelte.jp/docs/kit/introduction
 svg:
   name: SVG
   description: ベクター画像をXMLで記述する画像フォーマット
+  category: web-platform
   url: https://developer.mozilla.org/ja/docs/Web/SVG
 svg-js:
   name: SVG.js
   description: SVGの生成やアニメーションを扱う軽量なJavaScriptライブラリ
+  category: graphics
   url: https://svgjs.dev
 tailwind-css:
   name: Tailwind CSS
   description: ユーティリティクラスの組み合わせでスタイルを組み立てるCSSフレームワーク
+  category: web-platform
   url: https://tailwindcss.com/
 tanstack-query:
   name: TanStack Query
   description: 非同期データの取得・キャッシュ・同期を扱うデータフェッチライブラリ
+  category: ui-framework
   url: https://tanstack.com/query/latest
 tcolorbox:
   name: tcolorbox
   description: LaTeXで装飾付きのボックスを組版するパッケージ
+  category: authoring
   url: https://ctan.org/pkg/tcolorbox
 tex2img:
   name: tex2img
   description: LaTeXのソースコードから画像を生成できるWebサービス
+  category: authoring
   skill: false
   url: https://tex2img.tech/
 threejs:
   name: Three.js
   description: WebGLを扱いやすくする3DグラフィックスのJavaScriptライブラリ
+  category: graphics
   url: https://threejs.org/
 threlte:
   name: Threlte
   description: Three.jsをSvelteの宣言的なコンポーネントとして扱えるようにするライブラリ
+  category: graphics
   url: https://threlte.xyz/
 tikz:
   name: TikZ
   description: LaTeX文書の中に図を描画するためのパッケージ
+  category: authoring
   url: https://texwiki.texjp.org/TikZ
 tiptap:
   name: Tiptap
   description: ProseMirrorをベースにしたヘッドレスなリッチテキストエディタフレームワーク
+  category: authoring
   url: https://tiptap.dev/
 typescript:
   name: TypeScript
   description: JavaScriptに静的な型付けを加えたプログラミング言語
+  category: language
   url: https://www.typescriptlang.org/
 vba:
   name: VBA
   description: Officeアプリケーションの操作を自動化するためのプログラミング言語
+  category: language
   url: https://ja.wikipedia.org/wiki/Visual_Basic_for_Applications
 view-transition-api:
   name: View Transition API
   description: ページやDOMの状態変化にアニメーション付きの遷移を与えるブラウザAPI
+  category: web-platform
   url: https://developer.mozilla.org/ja/docs/Web/API/View_Transition_API
 vitest:
   name: Vitest
   description: Viteの設定をそのまま使えるJavaScriptのテストフレームワーク
+  category: tooling
   url: https://vitest.dev/
 vscode:
   name: VS Code
   description: Microsoftが開発する、拡張性の高いコードエディタ
+  category: tooling
   url: https://code.visualstudio.com/
 vuejs:
   name: Vue.js
   description: テンプレートとリアクティビティを軸にUIを構築するJavaScriptフレームワーク
+  category: ui-framework
   url: https://ja.vuejs.org/
 web-speech-api:
   name: Web Speech API
   description: 音声認識と音声合成をブラウザ上で扱うためのWeb API
+  category: web-platform
   url: https://developer.mozilla.org/ja/docs/Web/API/Web_Speech_API
 webgl:
   name: WebGL
   description: ブラウザ上でGPUを使った2D/3D描画を行うためのグラフィックスAPI
+  category: graphics
   url: https://developer.mozilla.org/ja/docs/Web/API/WebGL_API
 webgpu:
   name: WebGPU
   description: 現代的なGPUの機能をブラウザから扱うためのグラフィックスAPI
+  category: graphics
   url: https://developer.mozilla.org/ja/docs/Web/API/WebGPU_API
 wgpu:
   name: wgpu
   description: WebGPUの仕様に沿った、Rust製のクロスプラットフォームなグラフィックスAPI
+  category: graphics
   url: https://wgpu.rs/
 wgsl:
   name: WGSL
   description: WebGPUのシェーダを記述するためのプログラミング言語
+  category: graphics
   url: https://www.w3.org/TR/WGSL/
 winit:
   name: winit
   description: Rustでウィンドウの生成と入力イベントの処理を行うクロスプラットフォームなライブラリ
+  category: graphics
   url: https://github.com/rust-windowing/winit
 wordpress:
   name: WordPress
   description: 世界的に広く使われているオープンソースのCMS
+  category: ui-framework
   url: https://wordpress.com/ja/
 xparse:
   name: xparse
   description: LaTeXでコマンドの引数の受け取り方を柔軟に定義できるパッケージ
+  category: authoring
   skill: false
   url: https://ctan.org/pkg/xparse
 zod:
   name: Zod
   description: スキーマを定義して値を検証する、TypeScript向けのバリデーションライブラリ
+  category: data
   url: https://zod.dev/

--- a/src/lib/tag.ts
+++ b/src/lib/tag.ts
@@ -1,7 +1,7 @@
 import type { ReferenceDataEntry } from "astro:content"
 import { getCollection } from "astro:content"
 import { isNotDraft } from "$/lib/collection"
-import type { COMING_SOON_KEY } from "$/config"
+import type { COMING_SOON_KEY, SkillCategory } from "$/config"
 
 type RefTagEntryWithComingSoon = { data: { tags: ReferenceDataEntry<"tag">[]; date: Date | typeof COMING_SOON_KEY } }
 type RefTagEntry = { data: { tags: ReferenceDataEntry<"tag">[]; date: Date } }
@@ -16,10 +16,11 @@ export const getRefTagCollection = async (): Promise<RefTagEntry[]> => {
   return [...projects, ...events, ...techs, ...writings].flat()
 }
 
-export const getSkillTag = async (): Promise<string[]> => {
+/* skillタグのみを対象に、タグid -> 所属カテゴリの対応を返す。
+   キーの有無がそのままskillタグかどうかの判定になる */
+export const getSkillTagCategoryMap = async (): Promise<Map<string, SkillCategory>> => {
   const tags = await getCollection("tag")
-  const skillTagIds = tags.filter((tag) => tag.data.skill).map((tag) => tag.id)
-  return skillTagIds
+  return new Map(tags.filter((tag) => tag.data.skill).map((tag) => [tag.id, tag.data.category]))
 }
 
 export const collectTagIds = (targets: RefTagEntryWithComingSoon[]) => {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -130,7 +130,7 @@ const history = [
   }
   :is(.-highlight, .-history, .-skill-tag) {
     display: grid;
-    gap: 3rem;
+    gap: 2.5rem;
   }
   .Image-wrapper {
     width: fit-content;


### PR DESCRIPTION
トップページの Skill Tag を、これまでの件数降順フラット表示から、カテゴリごとに分けたグリッド表示に変更する。

## カテゴリ分類

「言語 / フレームワーク / ツール」のような形式的な分類ではなく、**その技術を何に使うか**で寄せている。そのため `glsl` / `wgsl` は言語ではなく Graphics に、`sql` は Data に属する。

| カテゴリ | 件数合計 | タグ数 |
| --- | --- | --- |
| Graphics & Visuals | 41 | 13 |
| UI Frameworks | 41 | 13 |
| Content Authoring | 33 | 14 |
| Web Platform | 25 | 6 |
| Tooling | 16 | 9 |
| Languages | 15 | 8 |
| Data | 8 | 6 |

- タグは**単一のカテゴリにのみ**所属する
- カテゴリ内の並び順は、従来どおり件数の降順
- カテゴリの表示順は、そのカテゴリに属するタグの**件数の合計が多い順**

## 実装

- `src/config.ts` — `SKILL_CATEGORY_META`（7カテゴリのラベル）と `SkillCategory` 型を追加
- `src/content.config.ts` — `tag` スキーマに `category` を**必須**で追加。カテゴリ未設定のタグを足すとビルドが落ちるため、`tag.yaml` への追記漏れを防げる
- `src/content/tag.yaml` — 全74タグに `category` を付与（`skill: false` の LaTeX パッケージ4件を含む）
- `src/lib/tag.ts` — `getSkillTag`（id配列）を `getSkillTagCategoryMap`（id → カテゴリの Map）に置き換え。キーの有無がそのまま skill タグ判定になる
- `src/components/pages/index/TagsList.astro` — カテゴリごとのグルーピングとグリッドレイアウト

## レイアウト

タグを flex の折り返しから grid に変更し、帯の幅をセルいっぱいに伸ばして、行と列のそろった塊として見せるようにした。

列幅の下限を `min(180px, (100% - gap) / 2)` とすることで、狭い画面でも1カラムに落ちず**最低2カラム**を保つ。あわせて、タグの `font-size` を 320px:12px → 375px:13px → 1024px:16px の2区間で遷移させている。

## 確認してほしいこと

- [ ] カテゴリの分類そのものに違和感がないか
- [ ] 狭い画面（320〜400px あたり）で、長いタグ名（`Rehype Pretty Code`、`Cloudflare Pages`）が隣の列に重なっていないか

## 公開状態

記事の追加・公開は含まない。トップページの表示のみの変更。
